### PR TITLE
Add options with custom URL slug and taxonomy name

### DIFF
--- a/_inc/admin-install-uninstall.php
+++ b/_inc/admin-install-uninstall.php
@@ -117,6 +117,8 @@ div.staff-member { display: block; }
 	$default_formatted_tag_string = implode(", ", $default_formatted_tags);
 	
 	$default_slug = 'staff-members';
+	$default_name_singular = _x( 'Staff Member', 'post type singular name', 'simple-staff-list' );
+	$default_name_plural = _x( 'Staff Members', 'post type general name', 'simple-staff-list' );
 
 	update_option('_staff_listing_default_tags', $default_tags );
 	update_option('_staff_listing_default_tag_string', $default_tag_string);
@@ -126,6 +128,8 @@ div.staff-member { display: block; }
 	update_option('_staff_listing_default_css', $default_css);
 
 	update_option('_staff_listing_default_slug', $default_slug);
+	update_option('_staff_listing_default_name_singular', $default_name_singular);
+	update_option('_staff_listing_default_name_plural', $default_name_plural);
 	
 	
 	if (!get_option('_staff_listing_custom_html')){
@@ -146,6 +150,14 @@ div.staff-member { display: block; }
 
 	if (!get_option('_staff_listing_custom_slug')){
 		update_option('_staff_listing_custom_slug', $default_slug);
+	}
+
+	if (!get_option('_staff_listing_custom_name_singular')){
+		update_option('_staff_listing_custom_name_singular', $default_name_singular);
+	}
+
+	if (!get_option('_staff_listing_custom_name_plural')){
+		update_option('_staff_listing_custom_name_plural', $default_name_plural);
 	}
 	
 	if ($is_forced != 'forced activation'){

--- a/_inc/admin-install-uninstall.php
+++ b/_inc/admin-install-uninstall.php
@@ -116,12 +116,16 @@ div.staff-member { display: block; }
 	$default_formatted_tags = array('[staff-name-formatted]', '[staff-position-formatted]', '[staff-photo]', '[staff-email-link]', '[staff-bio-formatted]');
 	$default_formatted_tag_string = implode(", ", $default_formatted_tags);
 	
+	$default_slug = 'staff-members';
+
 	update_option('_staff_listing_default_tags', $default_tags );
 	update_option('_staff_listing_default_tag_string', $default_tag_string);
 	update_option('_staff_listing_default_formatted_tags', $default_formatted_tags );
 	update_option('_staff_listing_default_formatted_tag_string', $default_formatted_tag_string);
 	update_option('_staff_listing_default_html', $default_template);
 	update_option('_staff_listing_default_css', $default_css);
+
+	update_option('_staff_listing_default_slug', $default_slug);
 	
 	
 	if (!get_option('_staff_listing_custom_html')){
@@ -138,6 +142,10 @@ div.staff-member { display: block; }
 	} else if (file_exists($filename)) {
 		$custom_css = file_get_contents($filename);
 		update_option('_staff_listing_custom_css', $custom_css);
+	}
+
+	if (!get_option('_staff_listing_custom_slug')){
+		update_option('_staff_listing_custom_slug', $default_slug);
 	}
 	
 	if ($is_forced != 'forced activation'){

--- a/_inc/admin-views.php
+++ b/_inc/admin-views.php
@@ -347,5 +347,52 @@ function sslp_staff_member_template_page(){
     echo $output;
 
 }
- 
+
+
+
+
+
+/*
+// Build the 'Options' Page
+//////////////////////////////*/
+
+function sslp_staff_member_options_page(){ 
+
+	// Get existing options
+	$default_slug 					= get_option('_staff_listing_default_slug');
+    
+	// Check Nonce and then update options
+	if ( !empty($_POST) && check_admin_referer( 'staff-member-options', 'staff-list-options' ) ) {
+		update_option('_staff_listing_custom_slug', wp_unique_term_slug($_POST[ "staff-listing-slug"],'staff-member'));
+		
+		$custom_slug = stripslashes_deep(get_option('_staff_listing_custom_slug'));
+
+	} else {
+		$custom_slug = stripslashes_deep(get_option('_staff_listing_custom_slug'));
+		
+	}
+	
+	
+	$output .= '<div class="wrap sslp-options">';
+	$output .= '<div id="icon-edit" class="icon32 icon32-posts-staff-member"><br></div><h2>' . __( 'Simple Staff List' ) . '</h2>';
+	$output .= '<h2>Options</h2>';
+    
+    $output .= '<div>';
+    $output .= '<form method="post" action="">';
+    $output .= '<fieldset id="staff-listing-field-slug">';
+    $output .= '<legend class="sslp-field-label">' . __( 'Staff Members URL Slug' ) . '</legend>';
+    $output .= '<input type="text" name="staff-listing-slug" value="' . $custom_slug . '"></fieldset>';
+    $output .= '<p>' . __( 'The slug used for building the staff members URL. The current URL is: ' );
+	$output .= site_url($custom_slug) . '/';
+    $output .= '</p>';
+    
+    $output .= '<p><input type="submit" value="' . __( 'Save ALL Changes' ) . '" class="button button-primary button-large"></p><br /><br />';
+    
+    $output .= wp_nonce_field('staff-member-options', 'staff-list-options');
+    $output .= '</form>';
+    $output .= '</div>';
+        
+    echo $output;
+
+}
 ?>

--- a/_inc/admin-views.php
+++ b/_inc/admin-views.php
@@ -360,15 +360,23 @@ function sslp_staff_member_options_page(){
 
 	// Get existing options
 	$default_slug 					= get_option('_staff_listing_default_slug');
+	$default_name_singular			= get_option('_staff_listing_default_name_singular');
+	$default_name_plural			= get_option('_staff_listing_default_name_plural');
     
 	// Check Nonce and then update options
 	if ( !empty($_POST) && check_admin_referer( 'staff-member-options', 'staff-list-options' ) ) {
 		update_option('_staff_listing_custom_slug', wp_unique_term_slug($_POST[ "staff-listing-slug"],'staff-member'));
+		update_option('_staff_listing_custom_name_singular', $_POST[ "staff-listing-name-singular"]);
+		update_option('_staff_listing_custom_name_plural', $_POST[ "staff-listing-name-plural"]);
 		
 		$custom_slug = stripslashes_deep(get_option('_staff_listing_custom_slug'));
+		$custom_name_singular = stripslashes_deep(get_option('_staff_listing_custom_name_singular'));
+		$custom_name_plural = stripslashes_deep(get_option('_staff_listing_custom_name_plural'));
 
 	} else {
 		$custom_slug = stripslashes_deep(get_option('_staff_listing_custom_slug'));
+		$custom_name_singular = stripslashes_deep(get_option('_staff_listing_custom_name_singular'));
+		$custom_name_plural = stripslashes_deep(get_option('_staff_listing_custom_name_plural'));
 		
 	}
 	
@@ -379,13 +387,21 @@ function sslp_staff_member_options_page(){
     
     $output .= '<div>';
     $output .= '<form method="post" action="">';
-    $output .= '<fieldset id="staff-listing-field-slug">';
+    $output .= '<fieldset id="staff-listing-field-slug" class="sslp-fieldset">';
     $output .= '<legend class="sslp-field-label">' . __( 'Staff Members URL Slug' ) . '</legend>';
     $output .= '<input type="text" name="staff-listing-slug" value="' . $custom_slug . '"></fieldset>';
     $output .= '<p>' . __( 'The slug used for building the staff members URL. The current URL is: ' );
 	$output .= site_url($custom_slug) . '/';
     $output .= '</p>';
-    
+    $output .= '<fieldset id="staff-listing-field-name-plural" class="sslp-fieldset">';
+    $output .= '<legend class="sslp-field-label">' . __( 'Staff Member title' ) . '</legend>';
+    $output .= '<input type="text" name="staff-listing-name-plural" value="' . $custom_name_plural . '"></fieldset>';
+    $output .= '<p>' . __( 'The title that displays on the Staff Member archive page. Default is "Staff Members"' ) . '</p>';
+    $output .= '<fieldset id="staff-listing-field-name-singular" class="sslp-fieldset">';
+    $output .= '<legend class="sslp-field-label">' . __( 'Staff Member singular title' ) . '</legend>';
+    $output .= '<input type="text" name="staff-listing-name-singular" value="' . $custom_name_singular . '"></fieldset>';
+    $output .= '<p>' . __( 'The Staff Member taxonomy singular name. No need to change this unless you need to use the singular_name field in your theme. Default is "Staff Member"' ) . '</p>';
+
     $output .= '<p><input type="submit" value="' . __( 'Save ALL Changes' ) . '" class="button button-primary button-large"></p><br /><br />';
     
     $output .= wp_nonce_field('staff-member-options', 'staff-list-options');

--- a/simple-staff-list.php
+++ b/simple-staff-list.php
@@ -132,10 +132,20 @@ function sslp_staff_member_init() {
 	} else {
 		$sslp_slug = get_option('_staff_listing_custom_slug');
 	}
+	if (!get_option('_staff_listing_custom_name_singular')){
+		$sslp_singular = get_option('_staff_listing_default_name_singular');
+	} else {
+		$sslp_singular = get_option('_staff_listing_custom_name_singular');
+	}
+	if (!get_option('_staff_listing_custom_name_plural')){
+		$sslp_name = get_option('_staff_listing_default_name_plural');
+	} else {
+		$sslp_name = get_option('_staff_listing_custom_name_plural');
+	}
 
 	$labels = array(
-		'name'                => _x( 'Staff Members', 'post type general name', 'simple-staff-list' ),
-		'singular_name'       => _x( 'Staff Member', 'post type singular name', 'simple-staff-list' ),
+		'name'                => $sslp_name,
+		'singular_name'       => $sslp_singular,
 		'add_new'             => _x( 'Add New', 'staff member', 'simple-staff-list' ),
 		'add_new_item'        => __( 'Add New Staff Member', 'simple-staff-list' ),
 		'edit_item'           => __( 'Edit Staff Member', 'simple-staff-list' ),

--- a/simple-staff-list.php
+++ b/simple-staff-list.php
@@ -126,6 +126,13 @@ function load_sslp_textdomain() {
 add_action( 'init', 'sslp_staff_member_init' );
 
 function sslp_staff_member_init() {
+
+	if (!get_option('_staff_listing_custom_slug')){
+		$sslp_slug = get_option('_staff_listing_default_slug');
+	} else {
+		$sslp_slug = get_option('_staff_listing_custom_slug');
+	}
+
 	$labels = array(
 		'name'                => _x( 'Staff Members', 'post type general name', 'simple-staff-list' ),
 		'singular_name'       => _x( 'Staff Member', 'post type singular name', 'simple-staff-list' ),
@@ -155,7 +162,7 @@ function sslp_staff_member_init() {
         'has_archive' => true,
         'hierarchical' => false,
         'menu_position' => 100,
-        'rewrite' => array('slug'=>'staff-members','with_front'=>false),
+        'rewrite' => array('slug'=>$sslp_slug,'with_front'=>false),
         'supports' => array( 'title', 'thumbnail', 'excerpt' )
     );
 
@@ -321,11 +328,12 @@ function sslp_staff_member_custom_columns( $cols ) {
 /**
  * Registers sub pages for staff-member CPT
  * 
- * Adds "Order" and "Templates" page to WP nav. 
+ * Adds "Order", "Templates", and "Options" pages to WP nav. 
  * ALSO adds the print scripts action to load our js only on the pages we need it.
  *
  * @param    function    $order_page	    sets up the Order page
- * @param    function    $templates_page    sets up the Order page
+ * @param    function    $templates_page    sets up the Templates page
+ * @param    function    $options_page    sets up the Options page
  * 
  */
  
@@ -354,9 +362,18 @@ function sslp_staff_member_register_menu() {
 						'edit_pages', 'staff-member-usage',
 						'sslp_staff_member_usage_page'
 					);
+
+	$options_page 	= add_submenu_page(
+						'edit.php?post_type=staff-member',
+						__( 'Simple Staff List Options', 'simple-staff-list' ),
+						__( 'Options', 'simple-staff-list' ),
+						'edit_pages', 'staff-member-options',
+						'sslp_staff_member_options_page'
+					);
 	
 	add_action( 'admin_print_scripts-'.$order_page, 'sslp_staff_member_admin_print_scripts' );
 	add_action( 'admin_print_scripts-'.$templates_page, 'sslp_staff_member_admin_print_scripts' );
+	add_action( 'admin_print_scripts-'.$options_page, 'sslp_staff_member_admin_print_scripts' );
 }
 
 


### PR DESCRIPTION
In response to [this support ticket](https://wordpress.org/support/topic/change-staff-member-to-something-else) and my own needs, I added a new options page to the dashboard menu with the options to change the URL slug and rename the taxonomy. The appearance is ugly, but I added css classes to the form to make it easily styled. Translations were not included, but the hooks for translation should be in place.
