### PR TITLE
Corrected unexpected output error during activation

### DIFF
--- a/trunk/includes/class-simple-staff-list-activator.php
+++ b/trunk/includes/class-simple-staff-list-activator.php
@@ -164,7 +164,7 @@ class Simple_Staff_List_Activator {
 			update_option( '_staff_listing_custom_name_plural', $default_name_plural );
 		}
 
-		if ( true == $is_forced ) {
+		if ( true === $is_forced ) {
 			flush_rewrite_rules();
 		}
 	}

--- a/trunk/includes/class-simple-staff-list-activator.php
+++ b/trunk/includes/class-simple-staff-list-activator.php
@@ -31,7 +31,7 @@ class Simple_Staff_List_Activator {
 	 *
 	 * @param    $is_forced
 	 */
-	public static function activate( $is_forced ) {
+	public static function activate( $is_forced = false ) {
 		$default_template = '
 		[staff_loop]
 			<img class="staff-member-photo" src="[staff-photo-url]" alt="[staff-name] : [staff-position]">

--- a/trunk/includes/class-simple-staff-list-activator.php
+++ b/trunk/includes/class-simple-staff-list-activator.php
@@ -164,7 +164,7 @@ class Simple_Staff_List_Activator {
 			update_option( '_staff_listing_custom_name_plural', $default_name_plural );
 		}
 
-		if ( 'forced activation' != $is_forced ) {
+		if ( true == $is_forced ) {
 			flush_rewrite_rules();
 		}
 	}


### PR DESCRIPTION
Fixes #22

Output was an error notice due to the omitted parameter value,
$is_forced. It now defaults to false when no value is present.