### PR TITLE
Multiple shortcodes bug #42

### DIFF
--- a/trunk/includes/class-simple-staff-list.php
+++ b/trunk/includes/class-simple-staff-list.php
@@ -115,8 +115,12 @@ class Simple_Staff_List {
 
 		/**
 		 * A utility class for creating custom post types
+		 *	- not required at this point...it's in here for later
+		 *   *** DOES NOT SUPPORT PHP 5.2 ***
 		 */
-		require_once plugin_dir_path( __FILE__ ) . 'class-custom-post-type.php';
+		if (version_compare(PHP_VERSION, '5.3.0') >= 0) {
+			require_once plugin_dir_path( __FILE__ ) . 'class-custom-post-type.php';
+		}
 
 		/**
 		 * The class responsible for defining all actions that occur in the public-facing

--- a/trunk/public/class-simple-staff-list-public.php
+++ b/trunk/public/class-simple-staff-list-public.php
@@ -60,7 +60,8 @@ class Simple_Staff_List_Public {
 
 		$this->plugin_name = $plugin_name;
 		$this->version     = $version;
-		$this->simple_staff_list_shortcode_atts = array(
+		$this->simple_staff_list_shortcode_atts = array();
+		$this->simple_staff_list_shortcode_atts_defaults = array(
 			'single' => 'no',
 			'group' => '',
 			'wrap_class' => '',
@@ -233,8 +234,9 @@ class Simple_Staff_List_Public {
 	public function staff_member_simple_staff_list_shortcode_callback( $atts = array() ) {
 
 		global $sslp_sc_output;
-		$this->simple_staff_list_shortcode_atts = shortcode_atts( $this->simple_staff_list_shortcode_atts, $atts, 'simple-staff-list' );
-		include_once( 'partials/simple-staff-list-shortcode-display.php' );
+
+		$this->simple_staff_list_shortcode_atts = shortcode_atts( $this->simple_staff_list_shortcode_atts_defaults, $atts, 'simple-staff-list' );
+		include( 'partials/simple-staff-list-shortcode-display.php' );
 		return $sslp_sc_output;
 
 	}


### PR DESCRIPTION
Looks like the problem was that
`$this->simple_staff_list_shortcode_atts` was being overwritten. So
each time through the shortcode, the defaults were being changed to
whatever atts were used during that iteration of the shortcode.

Fixes #42