### PR TITLE
Added [staff-phone-link] shortcode

### DIFF
--- a/trunk/includes/class-simple-staff-list-activator.php
+++ b/trunk/includes/class-simple-staff-list-activator.php
@@ -40,6 +40,7 @@ class Simple_Staff_List_Activator {
 				[staff-position-formatted]
 				[staff-bio-formatted]
 				[staff-email-link]
+				[staff-phone-link]
 			</div>
 		[/staff_loop]';
 
@@ -83,6 +84,9 @@ class Simple_Staff_List_Activator {
 			/*  [staff-email-link]  */
 			.staff-member-email {
 			}
+			/*  [staff-phone-link]  */
+			.staff-member-phone {
+			}
 			/*  [staff-name-formatted]  */
 			div.staff-member-listing h3.staff-member-name {
 				margin: 0;
@@ -121,6 +125,7 @@ class Simple_Staff_List_Activator {
 			'[staff-position-formatted]',
 			'[staff-photo]',
 			'[staff-email-link]',
+			'[staff-phone-link]',
 			'[staff-bio-formatted]'
 		);
 		$default_formatted_tag_string = implode( ", ", $default_formatted_tags );

--- a/trunk/public/partials/simple-staff-list-shortcode-display.php
+++ b/trunk/public/partials/simple-staff-list-shortcode-display.php
@@ -110,8 +110,9 @@
 		if (function_exists('wpautop')){
 			$bio_format = '<div class="staff-member-bio">'.wpautop($bio).'</div>';
 		}
-		
-		
+
+
+		$phone_link = '<a class="staff-member-phone" href="tel:'.antispambot( $phone ).'" title="Phone '.$name.'">'.antispambot( $phone ).'</a>';
 		$email_mailto = '<a class="staff-member-email" href="mailto:'.antispambot( $email ).'" title="Email '.$name.'">'.antispambot( $email ).'</a>';
 		$email_nolink = antispambot( $email );
 		
@@ -119,7 +120,7 @@
 		$replace_single_values = array($name, $name_slug, $photo_url, $title, $email_nolink, $phone, $bio, $fb_url, $tw_url);
 	
 		$accepted_formatted_tags = $default_formatted_tags;
-		$replace_formatted_values = array('<h3 class="staff-member-name">'.$name.'</h3>', '<h4 class="staff-member-position">'.$title.'</h4>', $photo, $email_mailto, $bio_format );
+		$replace_formatted_values = array('<h3 class="staff-member-name">'.$name.'</h3>', '<h4 class="staff-member-position">'.$title.'</h4>', $photo, $email_mailto, $phone_link, $bio_format );
 	
 		$loop_markup = str_replace($accepted_single_tags, $replace_single_values, $loop_markup);
 		$loop_markup = str_replace($accepted_formatted_tags, $replace_formatted_values, $loop_markup);


### PR DESCRIPTION
Newly implemented shortcode `[staff-phone-link]`. It formats phone number as a link
```HTML
<a href="tel:+1321654987">+1321654987</a>
```
which allows _click to call_.

For specification see [Google Developers document](https://developers.google.com/web/fundamentals/native-hardware/click-to-call/?hl=en) and [W3C article](https://www.w3.org/wiki/Introduction_to_mobile_web) (chapter _Cameras, phones and other hardware features_).