### PR TITLE
#49 Adding ability to define image size for staff loop

### DIFF
--- a/trunk/public/class-simple-staff-list-public.php
+++ b/trunk/public/class-simple-staff-list-public.php
@@ -66,6 +66,7 @@ class Simple_Staff_List_Public {
 			'group' => '',
 			'wrap_class' => '',
 			'order' => 'ASC',
+			'image_size' => 'full',
 		);
 
 		$this->staff_member_register_shortcodes();

--- a/trunk/public/partials/simple-staff-list-shortcode-display.php
+++ b/trunk/public/partials/simple-staff-list-shortcode-display.php
@@ -67,79 +67,90 @@
 	
 	$i = 0;
 	
-	if( $staff->have_posts() ) {
+	if( $staff->have_posts() ) :
 	
 		$output .= '<div class="staff-member-listing '.$group.'">';
 		
-	while( $staff->have_posts() ) : $staff->the_post();
-		
-		if ($i == ($staff->found_posts)-1) {
-			$staff_member_classes .= " last";
-		}
-		
-		if ($i % 2) {
-			$output .= '<div class="staff-member odd '.$staff_member_classes.'">';
-		} else {
-			$output .= '<div class="staff-member even '.$staff_member_classes.'">';
-		}
-		
-		global $post;
-		
-		$custom 	= get_post_custom();
-		$name 		= get_the_title();
-		$name_slug	= basename(get_permalink());
-		$title 		= $custom["_staff_member_title"][0];
-		$email 		= $custom["_staff_member_email"][0];
-		$phone 		= $custom["_staff_member_phone"][0];
-		$bio 		= $custom["_staff_member_bio"][0];
-		$fb_url		= $custom["_staff_member_fb"][0];
-		$tw_url		= 'http://www.twitter.com/' . $custom["_staff_member_tw"][0];
-		
-		
-		
-		if(has_post_thumbnail()){
+		while( $staff->have_posts() ) : $staff->the_post();
 			
-			$photo_url = wp_get_attachment_url( get_post_thumbnail_id() );
-			$photo = '<img class="staff-member-photo" src="'.$photo_url.'" alt = "'.$title.'">';
-		}else{
-			$photo_url = '';
-			$photo = '';
-		}
+			global $post;
+			
+			if ($i == ($staff->found_posts)-1) {
+				$staff_member_classes .= " last";
+			}
+			
+			if ($i % 2) {
+				$output .= '<div class="staff-member odd '.$staff_member_classes.'">';
+			} else {
+				$output .= '<div class="staff-member even '.$staff_member_classes.'">';
+			}
+			
+			global $post;
+			
+			$custom 	= get_post_custom();
+			$name 		= get_the_title();
+			$name_slug	= basename(get_permalink());
+			$title 		= $custom["_staff_member_title"][0];
+			$email 		= $custom["_staff_member_email"][0];
+			$phone 		= $custom["_staff_member_phone"][0];
+			$bio 		= $custom["_staff_member_bio"][0];
+			$fb_url		= $custom["_staff_member_fb"][0];
+			$tw_url		= 'http://www.twitter.com/' . $custom["_staff_member_tw"][0];
+			
+			
+			
+			if( has_post_thumbnail() ){
+				
+				$image_size = apply_filters( 'sslp_set_staff_image_size', $atts['image_size'], $post->ID );
+				
+				$image_obj = wp_get_attachment_image_src(get_post_thumbnail_id(), $image_size, false);
+	            $src = $image_obj[0];
+	           
+	            $photo_url = $src;
+	            $photo = '<img class="staff-member-photo" src="'.$photo_url.'" alt = "'.$title.'">';
+	            
+			}else{
+				
+				$photo_url = '';
+				$photo = '';
+				
+			}
+			
+			
+			if (function_exists('wpautop')){
+				$bio_format = '<div class="staff-member-bio">'.wpautop($bio).'</div>';
+			}
+			
+			
+			$email_mailto = '<a class="staff-member-email" href="mailto:'.antispambot( $email ).'" title="Email '.$name.'">'.antispambot( $email ).'</a>';
+			$email_nolink = antispambot( $email );
+			
+			$accepted_single_tags = $default_tags;
+			$replace_single_values = array($name, $name_slug, $photo_url, $title, $email_nolink, $phone, $bio, $fb_url, $tw_url);
 		
+			$accepted_formatted_tags = $default_formatted_tags;
+			$replace_formatted_values = array('<h3 class="staff-member-name">'.$name.'</h3>', '<h4 class="staff-member-position">'.$title.'</h4>', $photo, $email_mailto, $bio_format );
 		
-		if (function_exists('wpautop')){
-			$bio_format = '<div class="staff-member-bio">'.wpautop($bio).'</div>';
-		}
+			$loop_markup = str_replace($accepted_single_tags, $replace_single_values, $loop_markup);
+			$loop_markup = str_replace($accepted_formatted_tags, $replace_formatted_values, $loop_markup);
 		
+			$output .= $loop_markup;
 		
-		$email_mailto = '<a class="staff-member-email" href="mailto:'.antispambot( $email ).'" title="Email '.$name.'">'.antispambot( $email ).'</a>';
-		$email_nolink = antispambot( $email );
+			$loop_markup = $loop_markup_reset;
+			
+			
+			
+			$output .= '</div> <!-- Close staff-member -->';
+			$i += 1;
 		
-		$accepted_single_tags = $default_tags;
-		$replace_single_values = array($name, $name_slug, $photo_url, $title, $email_nolink, $phone, $bio, $fb_url, $tw_url);
-	
-		$accepted_formatted_tags = $default_formatted_tags;
-		$replace_formatted_values = array('<h3 class="staff-member-name">'.$name.'</h3>', '<h4 class="staff-member-position">'.$title.'</h4>', $photo, $email_mailto, $bio_format );
-	
-		$loop_markup = str_replace($accepted_single_tags, $replace_single_values, $loop_markup);
-		$loop_markup = str_replace($accepted_formatted_tags, $replace_formatted_values, $loop_markup);
-	
-		$output .= $loop_markup;
-	
-		$loop_markup = $loop_markup_reset;
+			
+		endwhile;
 		
+		$output .= "</div> <!-- Close staff-member-listing -->";
 		
+		wp_reset_postdata();
 		
-		$output .= '</div> <!-- Close staff-member -->';
-		$i += 1;
-	
-		
-	endwhile;
-	
-	$output .= "</div> <!-- Close staff-member-listing -->";
-	}
-	
-	wp_reset_query();
+	endif;
 	
 	$output = $style_output.$output;
 	


### PR DESCRIPTION
- Use the `image_size` attribute to specify which image size to use for
  your `simple-staff-list` shortcode.
- Use the ‘sslp_set_staff_image_size` filter to set the default image
  size
