### PR TITLE
#62 Efficiently flush the rewrite rules upon plugin activation

### DIFF
--- a/trunk/includes/class-simple-staff-list-activator.php
+++ b/trunk/includes/class-simple-staff-list-activator.php
@@ -164,8 +164,11 @@ class Simple_Staff_List_Activator {
 			update_option( '_staff_listing_custom_name_plural', $default_name_plural );
 		}
 
-		if ( true === $is_forced ) {
-			flush_rewrite_rules();
+		// Maybe add flag to signal the need to flush the rewrite rules
+		if ( ! get_option( '_staff_listing_flush_rewrite_rules_flag' ) ) {
+			
+			add_option( '_staff_listing_flush_rewrite_rules_flag', true );
+			
 		}
 	}
 

--- a/trunk/includes/class-simple-staff-list.php
+++ b/trunk/includes/class-simple-staff-list.php
@@ -190,7 +190,8 @@ class Simple_Staff_List {
 
 		$this->loader->add_action( 'wp_enqueue_scripts', $plugin_public, 'enqueue_styles' );
 		$this->loader->add_action( 'wp_enqueue_scripts', $plugin_public, 'enqueue_scripts' );
-		$this->loader->add_action( 'init', $plugin_public, 'staff_member_init' );
+		$this->loader->add_action( 'init', $plugin_public, 'staff_member_init', 10 );
+		$this->loader->add_action( 'init', $plugin_public, 'maybe_flush_rewrite_rules', 20 );
 
 	}
 

--- a/trunk/public/class-simple-staff-list-public.php
+++ b/trunk/public/class-simple-staff-list-public.php
@@ -224,7 +224,27 @@ class Simple_Staff_List_Public {
 			) );
 
 	}
-
+	
+	/**
+	 * Maybe flush rewrite rules
+	 *
+	 * @since 2.0
+	 */
+	public function maybe_flush_rewrite_rules() {
+		
+		if ( get_option( '_staff_listing_flush_rewrite_rules_flag' ) ) {
+			
+			// Flush the rewrite rules
+	        flush_rewrite_rules();
+	        
+	        // Remove our flag
+	        delete_option( '_staff_listing_flush_rewrite_rules_flag' );
+	        
+	    }
+	    
+	}
+	
+	
 	/**
 	 * Register plugin shortcode(s)
 	 *


### PR DESCRIPTION
- This should fix any 404 errors for people trying to access their
  staff members by going to `mysite.com/staff-members/staff-member-slug`
  or the `mysite.com.staff-members` archive page.
