### PR TITLE
Added an AJAX call to flush the rewrite rules on options save

### DIFF
--- a/trunk/admin/class-simple-staff-list-admin.php
+++ b/trunk/admin/class-simple-staff-list-admin.php
@@ -113,7 +113,19 @@ class Simple_Staff_List_Admin {
 
 	}
 
-
+	/**
+	 * Flush Rewrite Rules after saving plugin options
+	 *
+	 * @since   2.0
+	 */
+	public function ajax_flush_rewrite_rules() {
+		
+		flush_rewrite_rules();
+		
+		wp_send_json_success();
+		
+	}
+	
 	/**
 	 * Register admin menu items.
 	 *

--- a/trunk/admin/partials/simple-staff-list-options-display.php
+++ b/trunk/admin/partials/simple-staff-list-options-display.php
@@ -27,6 +27,20 @@ if ( !empty($_POST) && check_admin_referer( 'staff-member-options', 'staff-list-
 	$custom_slug = stripslashes_deep( get_option('_staff_listing_custom_slug') );
 	$custom_name_singular = stripslashes_deep( get_option('_staff_listing_custom_name_singular') );
 	$custom_name_plural = stripslashes_deep( get_option('_staff_listing_custom_name_plural') );
+	
+	// We've updated the options, send off an AJAX request to flush the rewrite rules
+	#TODO# Should move these options to use the Settings API instead of our own custom thing - or maybe just make it all AJAX - no need for a page refresh
+	?>
+	<script type="text/javascript">
+		jQuery(document).ready(function($) {
+			var data = {
+				'action': 'sslp_flush_rewrite_rules',
+			}
+			
+			$.post( "<?php echo admin_url( 'admin-ajax.php' ); ?>", data, function(response){});
+		});
+	</script>
+<?php
 
 } else {
 	$custom_slug = stripslashes_deep( get_option('_staff_listing_custom_slug') );

--- a/trunk/includes/class-simple-staff-list.php
+++ b/trunk/includes/class-simple-staff-list.php
@@ -164,6 +164,9 @@ class Simple_Staff_List {
 		$this->loader->add_action( 'admin_enqueue_scripts', $plugin_admin, 'enqueue_styles' );
 		$this->loader->add_action( 'admin_enqueue_scripts', $plugin_admin, 'enqueue_scripts' );
 		$this->loader->add_action( 'admin_menu', $plugin_admin, 'register_menu' );
+		
+		// Maybe flush rewrite rules after staff_member_init
+		$this->loader->add_action( 'wp_ajax_sslp_flush_rewrite_rules', $plugin_admin, 'ajax_flush_rewrite_rules', 20 );
 
 		$this->loader->add_filter( 'default_hidden_meta_boxes', $plugin_admin,  'hide_meta_boxes', 10, 2 );
 		$this->loader->add_filter( 'enter_title_here', $plugin_admin, 'staff_member_change_title' );


### PR DESCRIPTION
I forgot to account for when a user would change the `staff-member`
slug on the plugin options page. Changing the slug would result in 404s
but now, after detecting a settings change, we flush the rewrite rules
via AJAX. I did it this way because of the way the options page is
written. It just updates the values after the page refreshes, so
flushing them on the page is too late.