### PR TITLE
Simplify the post-thumbnails support for staff-member post type

### DIFF
--- a/trunk/README.txt
+++ b/trunk/README.txt
@@ -3,7 +3,7 @@ Contributors: brettshumaker
 Tags: staff list, staff directory, employee list, staff, employee, employees
 Requires at least: 3.0
 Tested up to: 4.9.6
-Stable tag: 2.1.0
+Stable tag: 2.1.1
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -46,6 +46,8 @@ Alright, here's a few things to try:
 
 == Changelog ==
 
+= 2.1.1 =
+* FIXED: post-thumbnail support for staff-member custom post type.
 
 = 2.1.0 =
 * FEATURE: Single Staff Member Templates - Learn more in this [blog post](https://brettshumaker.com/simple-staff-list-single-staff-member-templates "Simple Staff List - Single Staff Member Templates)

--- a/trunk/admin/class-simple-staff-list-admin.php
+++ b/trunk/admin/class-simple-staff-list-admin.php
@@ -290,18 +290,7 @@ class Simple_Staff_List_Admin {
 	 */
 	public function add_featured_image_support() {
 
-		$supported_types = get_theme_support( 'post-thumbnails' );
-
-		if ( false === $supported_types ) {
-
-			add_theme_support( 'post-thumbnails', 'staff-member' );
-
-		} elseif ( is_array( $supported_types ) ) {
-
-			$supported_types[0][] = 'staff-member';
-			add_theme_support( 'post-thumbnails', $supported_types[0] );
-
-		}
+		add_theme_support( 'post-thumbnails', array( 'staff-member' ) );
 
 	}
 

--- a/trunk/includes/class-simple-staff-list.php
+++ b/trunk/includes/class-simple-staff-list.php
@@ -68,7 +68,7 @@ class Simple_Staff_List {
 	public function __construct() {
 
 		$this->plugin_name = 'simple-staff-list';
-		$this->version     = '2.0.1';
+		$this->version     = '2.1.1';
 
 		$this->load_dependencies();
 		$this->set_locale();

--- a/trunk/simple-staff-list.php
+++ b/trunk/simple-staff-list.php
@@ -15,7 +15,7 @@
  * Plugin Name:       Simple Staff List
  * Plugin URI:        https://wordpress.org/plugins/simple-staff-list/
  * Description:       A simple plugin to build and display a staff listing for your website.
- * Version:           2.1.0
+ * Version:           2.1.1
  * Author:            Brett Shumaker
  * Author URI:        http://www.brettshumaker.com
  * License:           GPL-2.0+


### PR DESCRIPTION
I was doing some (I think) unnecessary checks around `add_theme_support( 'post-thumbnails' )` for the `staff-member` custom post type. I can safely declare it specifically for that post type without affecting anything else.