### PR TITLE
Limits the WP_Query posts_per_page to 100

### DIFF
--- a/trunk/public/partials/simple-staff-list-shortcode-display.php
+++ b/trunk/public/partials/simple-staff-list-shortcode-display.php
@@ -36,7 +36,7 @@
 	 */
 
 	$args = array(
-		'posts_per_page' => -1,
+		'posts_per_page' => 100,
 		'orderby'        => 'menu_order',
 		'post_status'    => 'publish',
 	);


### PR DESCRIPTION
Needed to set a sane default here instead of `-1`. If a user happened to have 100s or 1000s of staff members, using the shortcode could have caused trouble.

Closes #96 