### PR TITLE
Better Export for Custom Fields

### DIFF
--- a/trunk/admin/class-simple-staff-list-admin.php
+++ b/trunk/admin/class-simple-staff-list-admin.php
@@ -636,6 +636,9 @@ class Simple_Staff_List_Admin {
 
 			$csv_headers = array();
 			$csv_data    = array();
+		
+			//store keys to reference directly
+			$custom_keys = array();
 
 			while ( $staff_query->have_posts() ) :
 				$staff_query->the_post();
@@ -653,6 +656,8 @@ class Simple_Staff_List_Admin {
 							$new_key = trim( str_replace( '_', ' ', $key ) );
 
 							$csv_headers[] = ucwords( $new_key );
+							
+							$custom_keys[] = $key;
 
 						}
 					}
@@ -673,14 +678,13 @@ class Simple_Staff_List_Admin {
 					$csv_new_line[] = '';
 				}
 
-				// Get the post custom data.
-				foreach ( $custom as $key => $value ) {
-					if ( strpos( $key, '_staff_member_' ) !== false ) {
+				//Get the post custom data by direct reference instead of the original way which required columns (keys?) be in a specific order
+				foreach ( $custom_keys as $the_key ) {
+					if ( strpos( $the_key, '_staff_member_' ) !== false ){
+						
+						$new_value = $custom[$the_key][0];
 
-						$new_value = $value[0];
-
-						$csv_new_line[] = trim( $new_value );
-
+						$csv_new_line[] = trim( $new_value );	
 					}
 				}
 


### PR DESCRIPTION
I have added custom fields to SSLP via a custom plugin. For some reason, when I export the data the custom fields are out of order. (For example, I would have phone numbers showing in the Bio column on the csv.) If you write the custom data by directly referencing the key name (probably not saying that right) rather than looping through each key -> value pair, I can force the export to retain the correct order.

Not sure if that is useful to anyone else, but it works for me. Until there is support for custom fields in this plug in.