### PR TITLE
2.2.1

### DIFF
--- a/trunk/README.txt
+++ b/trunk/README.txt
@@ -47,8 +47,10 @@ Alright, here's a few things to try:
 == Changelog ==
 
 = 2.2.1 =
+* ADDED: Use the filter `sslp_staff_member_bio_kses_allowed_html` to change which HTML tags are allowed in the Staff Member bio field - it currently defaults to the `post` context. [Learn more](https://developer.wordpress.org/reference/functions/wp_kses/).
+* FIXED: Added some data sanitization and escaping
 * FIXED: Removed extra spacing on default values
-* CLEANED UP: 
+* CLEANED UP: Removed some old debugging code
 
 = 2.2.0 =
 * FEATURE: Use the `id` shortcode parameter to show a single Staff Member block

--- a/trunk/README.txt
+++ b/trunk/README.txt
@@ -2,7 +2,7 @@
 Contributors: brettshumaker
 Tags: staff list, staff directory, employee list, staff, employee, employees
 Requires at least: 3.0
-Tested up to: 5.5
+Tested up to: 5.7
 Stable tag: 2.2.1
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/trunk/README.txt
+++ b/trunk/README.txt
@@ -2,8 +2,8 @@
 Contributors: brettshumaker
 Tags: staff list, staff directory, employee list, staff, employee, employees
 Requires at least: 3.0
-Tested up to: 5.2.1
-Stable tag: 2.2.0
+Tested up to: 5.5
+Stable tag: 2.2.1
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -45,6 +45,10 @@ Alright, here's a few things to try:
 5. Templates screen 2
 
 == Changelog ==
+
+= 2.2.1 =
+* FIXED: Removed extra spacing on default values
+* CLEANED UP: 
 
 = 2.2.0 =
 * FEATURE: Use the `id` shortcode parameter to show a single Staff Member block

--- a/trunk/admin/class-simple-staff-list-admin.php
+++ b/trunk/admin/class-simple-staff-list-admin.php
@@ -474,7 +474,7 @@ class Simple_Staff_List_Admin {
 
 		switch ( $column ) {
 			case 'id':
-				echo $post->ID;
+				echo esc_html( $post->ID );
 				break;
 			case 'photo':
 				if ( has_post_thumbnail() ) {
@@ -517,32 +517,32 @@ class Simple_Staff_List_Admin {
 		update_post_meta(
 			$post->ID,
 			'_staff_member_bio',
-			isset( $_POST['_staff_member_bio'] ) ? $_POST['_staff_member_bio'] : ''
+			isset( $_POST['_staff_member_bio'] ) ? wp_kses( $_POST['_staff_member_bio'], apply_filters( 'sslp_staff_member_bio_kses_allowed_html', 'post' ) ) : ''
 		);
 		update_post_meta(
 			$post->ID,
 			'_staff_member_title',
-			isset( $_POST['_staff_member_title'] ) ? $_POST['_staff_member_title'] : ''
+			isset( $_POST['_staff_member_title'] ) ? sanitize_text_field( $_POST['_staff_member_title'] ) : ''
 		);
 		update_post_meta(
 			$post->ID,
 			'_staff_member_email',
-			isset( $_POST['_staff_member_email'] ) ? $_POST['_staff_member_email'] : ''
+			isset( $_POST['_staff_member_email'] ) ? sanitize_email( $_POST['_staff_member_email'] ) : ''
 		);
 		update_post_meta(
 			$post->ID,
 			'_staff_member_phone',
-			isset( $_POST['_staff_member_phone'] ) ? $_POST['_staff_member_phone'] : ''
+			isset( $_POST['_staff_member_phone'] ) ? sanitize_text_field( $_POST['_staff_member_phone'] ) : ''
 		);
 		update_post_meta(
 			$post->ID,
 			'_staff_member_fb',
-			isset( $_POST['_staff_member_fb'] ) ? $_POST['_staff_member_fb'] : ''
+			isset( $_POST['_staff_member_fb'] ) ? sanitize_text_field( $_POST['_staff_member_fb'] ) : ''
 		);
 		update_post_meta(
 			$post->ID,
 			'_staff_member_tw',
-			isset( $_POST['_staff_member_tw'] ) ? $_POST['_staff_member_tw'] : ''
+			isset( $_POST['_staff_member_tw'] ) ? sanitize_text_field( $_POST['_staff_member_tw'] ) : ''
 		);
 
 	}
@@ -591,7 +591,6 @@ class Simple_Staff_List_Admin {
 			wp_send_json_error( "Cheatin' uh?" );
 		}
 
-		$post_type = $_POST['postType'];
 		$order     = $_POST['order'];
 
 		/**

--- a/trunk/includes/class-simple-staff-list-activator.php
+++ b/trunk/includes/class-simple-staff-list-activator.php
@@ -31,76 +31,9 @@ class Simple_Staff_List_Activator {
 	 * @param    bool $is_forced Whether or not the "activation" function was forced to run.
 	 */
 	public static function activate( $is_forced = false ) {
-		$default_template = '
-		[staff_loop]
-			<img class="staff-member-photo" src="[staff-photo-url]" alt="[staff-name] : [staff-position]">
-			<div class="staff-member-info-wrap">
-				[staff-name-formatted]
-				[staff-position-formatted]
-				[staff-bio-formatted]
-				[staff-email-link]
-			</div>
-		[/staff_loop]';
+		$default_template = "[staff_loop]\n    <img class=\"staff-member-photo\" src=\"[staff-photo-url]\" alt=\"[staff-name] : [staff-position]\">\n    <div class=\"staff-member-info-wrap\">\n        [staff-name-formatted]\n        [staff-position-formatted]\n        [staff-bio-formatted]\n        [staff-email-link]\n    </div>\n[/staff_loop]";
 
-		$default_css = '
-			/*  div wrapped around entire staff list  */
-			div.staff-member-listing {
-			}
-			/*  div wrapped around each staff member  */
-			div.staff-member {
-				padding-bottom: 2em;
-				border-bottom: thin dotted #aaa;
-			}
-			/*  "Even" staff member  */
-			div.staff-member.even {
-			}
-			/*  "Odd" staff member  */
-			div.staff-member.odd {
-				margin-top: 2em;
-			}
-			/*  Last staff member  */
-			div.staff-member.last {
-				padding-bottom: 0;
-				border: none;
-			}
-			/*  Wrap around staff info  */
-			.staff-member-info-wrap {
-				float: left;
-				width: 70%;
-				margin-left: 3%;
-			}
-			/*  [staff-bio-formatted]  */
-			div.staff-member-bio {
-			}
-			/*  p tags within [staff-bio-formatted]  */
-			div.staff-member-bio p {
-			}
-			/*  [staff-photo]  */
-			img.staff-member-photo {
-				float: left;
-			}
-			/*  [staff-email-link]  */
-			.staff-member-email {
-			}
-			/*  [staff-name-formatted]  */
-			div.staff-member-listing h3.staff-member-name {
-				margin: 0;
-			}
-			/*  [staff-position-formatted]  */
-			div.staff-member-listing h4.staff-member-position {
-				margin: 0;
-				font-style: italic;
-			}
-			/* Clearfix for div.staff-member */
-			div.staff-member:after {
-				content: "";
-				display: block;
-				clear: both;
-			}
-			/* Clearfix for <= IE7 */
-			* html div.staff-member { height: 1%; }
-			div.staff-member { display: block; }
-		';
+		$default_css = "/*  div wrapped around entire staff list  */\n    div.staff-member-listing {\n}\n/*  div wrapped around each staff member  */\ndiv.staff-member {\n    padding-bottom: 2em;\n    border-bottom: thin dotted #aaa;\n}\n/*  Even staff member  */\ndiv.staff-member.even {\n}\n/*  Odd staff member  */\ndiv.staff-member.odd {\n    margin-top: 2em;\n}\n/*  Last staff member  */\ndiv.staff-member.last {\n    padding-bottom: 0;\n    border: none;\n}\n/*  Wrap around staff info  */\n.staff-member-info-wrap {\n    float: left;\n    width: 70%;\n    margin-left: 3%;\n}\n/*  [staff-bio-formatted]  */\ndiv.staff-member-bio {\n}\n/*  p tags within [staff-bio-formatted]  */\ndiv.staff-member-bio p {\n}\n/*  [staff-photo]  */\nimg.staff-member-photo {\n    float: left;\n}\n/*  [staff-email-link]  */\n.staff-member-email {\n}\n/*  [staff-name-formatted]  */\ndiv.staff-member-listing h3.staff-member-name {\n    margin: 0;\n}\n/*  [staff-position-formatted]  */\ndiv.staff-member-listing h4.staff-member-position {\n    margin: 0;\n    font-style: italic;\n}\n/* Clearfix for div.staff-member */\ndiv.staff-member:after {\n    content: \"\";\n    display: block;\n    clear: both;\n}\n/* Clearfix for <= IE7 */\n* html div.staff-member { height: 1%; }\ndiv.staff-member { display: block; }\n";
 
 		$default_tags       = array(
 			'[staff-name]',

--- a/trunk/includes/class-simple-staff-list.php
+++ b/trunk/includes/class-simple-staff-list.php
@@ -68,7 +68,7 @@ class Simple_Staff_List {
 	public function __construct() {
 
 		$this->plugin_name = 'simple-staff-list';
-		$this->version     = '2.2.0';
+		$this->version     = '2.2.1';
 
 		$this->load_dependencies();
 		$this->set_locale();

--- a/trunk/includes/sslp-core-functions.php
+++ b/trunk/includes/sslp-core-functions.php
@@ -33,8 +33,6 @@ function sslp_get_template_part( $slug = '' ) {
 	// Allow 3rd party plugins to filter template file from their plugin.
 	$template = apply_filters( 'sslp_get_template_part', $template, $slug );
 
-	//wp_die( $template );
-
 	if ( $template ) {
 		load_template( $template, false );
 	}

--- a/trunk/public/partials/simple-staff-list-shortcode-display.php
+++ b/trunk/public/partials/simple-staff-list-shortcode-display.php
@@ -91,7 +91,7 @@
 
 	// Prepare to output styles if not using external style sheet.
 	if ( 'no' === $use_external_css ) {
-		$style_output = '<style>' . $custom_css . '</style>';
+		$style_output = '<style>' . esc_html( $custom_css ) . '</style>';
 	} else {
 		$style_output = ''; }
 
@@ -120,16 +120,16 @@
 
 			$custom          = get_post_custom();
 			$name            = get_the_title();
-			$name_formatted  = '<h3 class="staff-member-name">' . $name . '</h3>';
+			$name_formatted  = '<h3 class="staff-member-name">' . esc_html( $name ) . '</h3>';
 			$name_slug       = basename( get_permalink() );
 			$title           = isset( $custom['_staff_member_title'][0] ) ? $custom['_staff_member_title'][0] : '';
-			$title_formatted = '' !== $title ? '<h4 class="staff-member-position">' . $title . '</h4>' : '';
+			$title_formatted = '' !== $title ? '<h4 class="staff-member-position">' . esc_html( $title ) . '</h4>' : '';
 			$email           = isset( $custom['_staff_member_email'][0] ) ? $custom['_staff_member_email'][0] : '';
 			$phone           = isset( $custom['_staff_member_phone'][0] ) ? $custom['_staff_member_phone'][0] : '';
 			$bio             = isset( $custom['_staff_member_bio'][0] ) ? $custom['_staff_member_bio'][0] : '';
 			$fb_url          = isset( $custom['_staff_member_fb'][0] ) ? $custom['_staff_member_fb'][0] : '';
 			$tw_url          = isset( $custom['_staff_member_tw'][0] ) ? 'http://www.twitter.com/' . $custom['_staff_member_tw'][0] : '';
-			$email_mailto    = '' !== $email ? '<a class="staff-member-email" href="mailto:' . antispambot( $email ) . '" title="Email ' . $name . '">' . antispambot( $email ) . '</a>' : '';
+			$email_mailto    = '' !== $email ? '<a class="staff-member-email" href="mailto:' . esc_attr( antispambot( $email ) ) . '" title="Email ' . esc_attr( $name ) . '">' . esc_html( antispambot( $email ) ) . '</a>' : '';
 			$email_nolink    = '' !== $email ? antispambot( $email ) : '';
 
 			if ( has_post_thumbnail() ) {
@@ -140,7 +140,7 @@
 				$src       = $image_obj[0];
 
 				$photo_url = $src;
-				$photo     = '<img class="staff-member-photo" src="' . $photo_url . '" alt = "' . $title . '">';
+				$photo     = '<img class="staff-member-photo" src="' . esc_url( $photo_url ) . '" alt = "' . esc_attr( $title ) . '">';
 
 			} else {
 
@@ -151,16 +151,16 @@
 
 			if ( function_exists( 'wpautop' ) ) {
 
-				$bio_format = '' !== $bio ? '<div class="staff-member-bio">' . wpautop( $bio ) . '</div>' : '';
+				$bio_format = '' !== $bio ? '<div class="staff-member-bio">' . wp_kses( wpautop( $bio ), apply_filters( 'sslp_staff_member_bio_kses_allowed_html', 'post' ) ) . '</div>' : '';
 
 			} else {
 
-				$bio_format = $bio;
+				$bio_format = wp_kses( $bio, apply_filters( 'sslp_staff_member_bio_kses_allowed_html', 'post' ) );
 
 			}
 
 			$accepted_single_tags  = $default_tags;
-			$replace_single_values = apply_filters( 'sslp_replace_single_values_filter', array( $name, $name_slug, $photo_url, $title, $email_nolink, $phone, $bio, $fb_url, $tw_url ), $post->ID );
+			$replace_single_values = apply_filters( 'sslp_replace_single_values_filter', array( esc_html( $name ), esc_attr( $name_slug ), esc_url( $photo_url ), esc_html( $title ), esc_html( $email_nolink ), esc_html( $phone ), wp_kses( $bio, apply_filters( 'sslp_staff_member_bio_kses_allowed_html', 'post' ) ), esc_html( $fb_url ), esc_url( $tw_url ) ), $post->ID );
 
 			$accepted_formatted_tags  = $default_formatted_tags;
 			$replace_formatted_values = apply_filters( 'sslp_replace_formatted_values_filter', array( $name_formatted, $title_formatted, $photo, $email_mailto, $bio_format ), $post->ID );

--- a/trunk/public/templates/single-staff-member/staff-bio.php
+++ b/trunk/public/templates/single-staff-member/staff-bio.php
@@ -13,4 +13,4 @@
 
 $bio = get_post_meta( $post->ID, '_staff_member_bio', true );
 
-echo wpautop( $bio );
+echo wp_kses( wpautop( $bio ), apply_filters( 'sslp_staff_member_bio_kses_allowed_html', 'post' ) );

--- a/trunk/public/templates/single-staff-member/staff-facebook.php
+++ b/trunk/public/templates/single-staff-member/staff-facebook.php
@@ -24,6 +24,6 @@ if ( '' !== $facebook ) {
 		$icon = $svg['body'];
 	}
 
-	echo '<span class="facebook"><a class="staff-member-facebook" href="' . esc_attr( $facebook ) . '" title="Find ' . esc_attr( get_the_title() ) . ' on Facebook">' . $icon . '</a></span>';
+	echo '<span class="facebook"><a class="staff-member-facebook" href="' . esc_url( $facebook ) . '" title="Find ' . esc_attr( get_the_title() ) . ' on Facebook">' . $icon . '</a></span>';
 
 }

--- a/trunk/public/templates/single-staff-member/staff-image.php
+++ b/trunk/public/templates/single-staff-member/staff-image.php
@@ -18,4 +18,4 @@ if ( ! defined( 'ABSPATH' ) ) {
 $image_obj = wp_get_attachment_image_src( get_post_thumbnail_id(), 'medium', false );
 $src       = $image_obj[0];
 ?>
-<img class="staff-member-photo" src="<?php echo esc_attr( $src ); ?>" alt = "<?php echo esc_attr( get_the_title() ); ?>">
+<img class="staff-member-photo" src="<?php echo esc_url( $src ); ?>" alt = "<?php echo esc_attr( get_the_title() ); ?>">

--- a/trunk/simple-staff-list.php
+++ b/trunk/simple-staff-list.php
@@ -15,7 +15,7 @@
  * Plugin Name:       Simple Staff List
  * Plugin URI:        https://wordpress.org/plugins/simple-staff-list/
  * Description:       A simple plugin to build and display a staff listing for your website.
- * Version:           2.2.0
+ * Version:           2.2.1
  * Author:            Brett Shumaker
  * Author URI:        http://www.brettshumaker.com
  * License:           GPL-2.0+

--- a/trunk/trunk
+++ b/trunk/trunk
@@ -1,0 +1,1 @@
+/vagrant/simple-staff-list/trunk


### PR DESCRIPTION
* ADDED: Use the filter `sslp_staff_member_bio_kses_allowed_html` to change which HTML tags are allowed in the Staff Member bio field - it currently defaults to the `post` context. [Learn more](https://developer.wordpress.org/reference/functions/wp_kses/).
* FIXED: Added some data sanitization and escaping
* FIXED: Removed extra spacing on default values
* CLEANED UP: Removed some old debugging code