### PR TITLE
Adds the ability for users to add fields to SSLP

### DIFF
--- a/staff-list-plugin.php
+++ b/staff-list-plugin.php
@@ -1,0 +1,28 @@
+<?php
+/*
+Plugin Name: Lifecycle Insights Product Access Options
+Plugin URI: http://lifecycleinsights.com
+Description: Adds cost of goods to products and generates reports
+Version: 1.0
+Author: SFNdesign, Curtis McHale
+Author URI: http://sfndesign.ca
+License: GPLv2 or later
+*/
+
+/*
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+*/
+
+require_once( 'trunk/simple-staff-list.php');

--- a/staff-list-plugin.php
+++ b/staff-list-plugin.php
@@ -1,11 +1,11 @@
 <?php
 /*
-Plugin Name: Lifecycle Insights Product Access Options
-Plugin URI: http://lifecycleinsights.com
-Description: Adds cost of goods to products and generates reports
+Plugin Name: TEMP - Simple Staff List
+Plugin URI: https://github.com/brettshumaker/Staff-List-Plugin
+Description: Duplicates the Simple Staff List plugin with features that are coming but we need now.
 Version: 1.0
-Author: SFNdesign, Curtis McHale
-Author URI: http://sfndesign.ca
+Author: ProudCity, Curtis McHale
+Author URI: http://proudcity.com
 License: GPLv2 or later
 */
 

--- a/trunk/README.txt
+++ b/trunk/README.txt
@@ -46,6 +46,11 @@ Alright, here's a few things to try:
 
 == Changelog ==
 
+= 2.2.2 =
+
+- added `sslp_after_staff_member_admin_fields` which passes `$post->ID` so a user can add their own fields to the metabox
+- added `sslp_save_staff_member_details' which passes `$post->ID` and `$_POST` so that users can save their own custom fields
+
 = 2.2.1 =
 * ADDED: Use the filter `sslp_staff_member_bio_kses_allowed_html` to change which HTML tags are allowed in the Staff Member bio field - it currently defaults to the `post` context. [Learn more](https://developer.wordpress.org/reference/functions/wp_kses/).
 * FIXED: Added some data sanitization and escaping

--- a/trunk/admin/class-simple-staff-list-admin.php
+++ b/trunk/admin/class-simple-staff-list-admin.php
@@ -404,10 +404,11 @@ class Simple_Staff_List_Admin {
 						placeholder="<?php esc_attr_e( 'Staff Member\'s Twitter Name', $this->plugin_name ); ?>"
 						value="<?php echo esc_attr( $_staff_member_tw ); ?>"/>
 			</label>
+			
+			<?php do_action( 'sslp_after_staff_member_admin_fields', absint( $post->ID ) ); ?>
+			
 		</div>
 		<?php
-		
-		do_action( 'sslp_after_staff_member_admin_fields', absint( $post->ID ) );
 
 	}
 

--- a/trunk/admin/class-simple-staff-list-admin.php
+++ b/trunk/admin/class-simple-staff-list-admin.php
@@ -406,6 +406,8 @@ class Simple_Staff_List_Admin {
 			</label>
 		</div>
 		<?php
+		
+		do_action( 'sslp_after_staff_member_admin_fields', absint( $post->ID ) );
 
 	}
 
@@ -544,6 +546,8 @@ class Simple_Staff_List_Admin {
 			'_staff_member_tw',
 			isset( $_POST['_staff_member_tw'] ) ? sanitize_text_field( $_POST['_staff_member_tw'] ) : ''
 		);
+		
+		do_action( 'sslp_save_staff_member_details', absint( $post->ID ), $_POST );
 
 	}
 

--- a/trunk/admin/css/simple-staff-list-admin.css
+++ b/trunk/admin/css/simple-staff-list-admin.css
@@ -15,9 +15,16 @@
 	margin:10px 0 0;
 }
 
-.sslp_admin_wrap input[type="text"] {
+.sslp_admin_wrap input[type="text"],
+.sslp_admin_wrap input[type="url"]{
 	font-family: "HelveticaNeue-Light","Helvetica Neue Light","Helvetica Neue",sans-serif;
 	width: 30%;
+}
+
+.sslp_admin_wrap textarea{
+	font-family: "HelveticaNeue-Light","Helvetica Neue Light","Helvetica Neue",sans-serif;
+	width:80%;
+	height:100px;
 }
 
 #wp-_staff_member_bio-wrap .wp-editor-area {


### PR DESCRIPTION
This adds two hooks so that users can add and save field data. It also adds a few more CSS rules so that other field types will match with SSLP existing fields.